### PR TITLE
More bug fixes in VideoProcessing

### DIFF
--- a/MarioMaker2OCR/Form1.cs
+++ b/MarioMaker2OCR/Form1.cs
@@ -204,10 +204,14 @@ namespace MarioMaker2OCR
 
         private void stopButton_Click(object sender, EventArgs e)
         {
-            BeginInvoke(new MethodInvoker(() => unlockForm()));
             SMMServer.Stop();
-            processor?.Stop();
-            processor = null;
+            if(processor != null)
+            {
+                processor.Stop();
+                processor.Dispose();
+                processor = null;
+            }
+            BeginInvoke(new MethodInvoker(() => unlockForm()));
         }
 
         private void lockForm()


### PR DESCRIPTION
Mostly related to restarting the processor after having stopped it. 

The Stop() function doesn't return until the thread has stopped, not just Abort() called. The frameBuffer tick also checks if the processor thread is alive to prevent it from trying to read and add frames when it shouldn't be working.

Also, its a little dirty, but I've wrapped the video processing stuff in a generic try/catch to log the errors and have it looping to try and restart automatically.

It should give us logging information to try and figure out where some crashes are coming from as long as its not a AccessViolationException which can't be caught...which unfortunately I suspect is the issue.