### PR TITLE
Add config for travis-ci to generate auto-releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: csharp
+solution: MarioMaker2OCR.sln
+
+before_deploy:
+  # Set up git user name and tag this commit
+  - git config --local user.name $GITHUB_NAME
+  - git config --local user.email $GITHUB_EMAIL
+  - export TRAVIS_TAG=${TRAVIS_TAG:-$(date +'%Y%m%d%H%M%S')-$(git log --format=%h -1)}
+  - git tag $TRAVIS_TAG
+  - cd MarioMaker2OCR/bin
+  - mv Release MarioMaker2OCR
+  - zip -r MarioMaker2OCR.zip MarioMaker2OCR
+  - cd ../../
+
+deploy:
+  provider: releases
+  api_key: $GITHUB_KEY
+  file: "MarioMaker2OCR/bin/MarioMaker2OCR.zip"
+  skip_cleanup: true


### PR DESCRIPTION
The build script automatically builds (using mono, but it seems to work) , zips the Release/ folder and uploads it as a new Release whenever there is a push.

You do need to setup a travis-ci.org account, and 3 environment vars setup on travic-ci.org
GITHUB_NAME - your user.name for github
GITHUB_EMAIl - email for github
GITUP_KEY - API key from github